### PR TITLE
Make mathjax-electron async

### DIFF
--- a/src/mathjax-electron.js
+++ b/src/mathjax-electron.js
@@ -3,12 +3,14 @@
 var path = require('path');
 
 module.exports = {
-    loadMathJax: function(document) {
+    loadMathJax: function(document, callback) {
+        callback = (typeof callback === 'function') ? callback : function() {};
         if (typeof MathJax === "undefined" || MathJax === null) {
             var script = document.createElement("script");
 
             script.addEventListener("load", function() {
                 configureMathJax();
+                callback();
             });
             script.type = "text/javascript";
 
@@ -20,24 +22,25 @@ module.exports = {
             } catch (error) {
                 throw new Error(error.message, "loadMathJax");
             }
+        } else {
+            callback();
         }
     },
 
-    mathProcessor: function(container) {
+    typesetMath: function(container, callback) {
+        callback = (typeof callback === 'function') ? callback : function() {};
         try {
-            typesetMath(container);
+            MathJax.Hub.Queue(["Typeset", MathJax.Hub, container], callback);
         } catch (error) {
-            try {
-                setTimeout(typesetMath, 1000, container)
-            } catch (error) {
-                throw new Error(error.message, "mathProcessor");
-            }
-        }
-    }
-};
+            throw new Error(error.message, "typesetMath");
+      }
+    },
 
-var typesetMath = function(container) {
-    MathJax.Hub.Queue(["Typeset", MathJax.Hub, container]);
+    mathProcessor: function(document, container, callback) {
+        this.loadMathJax(document, function () {
+            module.exports.typesetMath(container, callback);
+        });
+    }
 };
 
 var configureMathJax = function() {

--- a/test/mathjax-electron.test.js
+++ b/test/mathjax-electron.test.js
@@ -13,22 +13,35 @@ describe('latex transform', function() {
         return assert.equal(script, headScript);
     });
 
-    it('should output the correct MathJax script', function() {
+    it('should output the correct MathJax script', function(done) {
         let math = '\\sum\\limits_{i=0}^{\\infty} \\frac{1}{n^2}';
         let latex = '$$' + math + '$$';
 
         var container = document.createElement('div');
         container.innerHTML = latex
-        mathJaxHelper.loadMathJax(document);
-        mathJaxHelper.mathProcessor(container);
+        mathJaxHelper.loadMathJax(document, function () {
+            mathJaxHelper.typesetMath(container,
+            function () {
+                assert.lengthOf(container.getElementsByClassName('MathJax_SVG_Display'), 1);
+                assert.lengthOf(container.getElementsByClassName('MathJax_SVG'), 1);
+                assert.equal(container.getElementsByTagName('script')[0].textContent, math);
+                done();
+            })
+        });
+    });
 
-        return (new Promise(function(resolve) {
-            setTimeout(function() {resolve();}, 800);
-        })).then(function() {
+    it('should should load and typeset', function(done) {
+        let math = '\\sum\\limits_{i=0}^{\\infty} \\frac{1}{n^2}';
+        let latex = '$$' + math + '$$';
+
+        var container = document.createElement('div');
+        container.innerHTML = latex
+        mathJaxHelper.mathProcessor(document, container,
+        function () {
             assert.lengthOf(container.getElementsByClassName('MathJax_SVG_Display'), 1);
             assert.lengthOf(container.getElementsByClassName('MathJax_SVG'), 1);
-            assert.equal(container.getElementsByTagName('script')[0].textContent, math)
+            assert.equal(container.getElementsByTagName('script')[0].textContent, math);
+            done();
         });
-
     });
 });


### PR DESCRIPTION
- All functions async now return callbacks
- `mathProcessor` is a helper function which loads MathJax if necessary and typesets the latex.


@rgbkrk I'm pretty new to async programming. Can you take a look at this PR?
