### PR TITLE
Don't typeset on startup

### DIFF
--- a/resources/MathJax/config/electron.js
+++ b/resources/MathJax/config/electron.js
@@ -3,6 +3,7 @@ MathJax.Hub.Config({
   extensions: ["tex2jax.js"],
   messageStyle: "none",
   showMathMenu: false,
+  skipStartupTypeset: true,
   tex2jax: {
     inlineMath: [["$", "$"], ["\\(", "\\)"]],
     displayMath: [["$$", "$$"], ["\\[", "\\]"]],


### PR DESCRIPTION
From the docs:
> Normally MathJax will typeset the mathematics on the page as soon as the page is loaded. If you want to delay that process, in which case you will need to call MathJax.Hub.Typeset() yourself by hand, set this value to true.

I think this doesn't have a effect on nteract since we manually call `MathJax.Hub.Typeset()` if we want to typeset.

This prevents some funny behavior I just noticed in Hydrogen:
![mathjax](https://cloud.githubusercontent.com/assets/13285808/25299585/dae81a9e-2700-11e7-898e-5b27054b8353.gif)